### PR TITLE
changed entity detection to no longer rely on serial numbers

### DIFF
--- a/src/details.ts
+++ b/src/details.ts
@@ -24,10 +24,10 @@ export class GivTCPPowerFlowCardDetails extends LitElement {
 	render(): TemplateResult {
 		return html`<div class="gtpc-details">
 			${this.entities.map(
-				(entity) => html`<div class="gtpc-detail" data-entity-id="${entity.entity_id}">
-					<div class="gtpc-detail-title">${this.formatEntityName(entity.attributes.friendly_name)}</div>
+				(entity) => html`<div class="gtpc-detail" data-entity-id="${entity?.entity_id}">
+					<div class="gtpc-detail-title">${this.formatEntityName(entity?.attributes?.friendly_name)}</div>
 					<state-badge .stateObj=${entity} .stateColor=${true}></state-badge>
-					<div class="gtpc-detail-state">${entity.state} ${entity.attributes.unit_of_measurement}</div>
+					<div class="gtpc-detail-state">${entity?.state} ${entity?.attributes?.unit_of_measurement}</div>
 				</div>`
 			)}
 		</div>`;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -107,18 +107,10 @@ export class GivTCPPowerFlowCardEditor extends LitElement implements LovelaceCar
 		}
 	}
 	private get _batteries(): string[] {
-		return this.hass
-			? Object.keys(this.hass.states).filter((eid) =>
-					/^sensor\.givtcp_[a-zA-Z]{2}\d{4}[a-zA-Z]\d{3}_battery_serial_number$/g.test(eid)
-			  )
-			: [];
+		return this.hass ? Object.keys(this.hass.states).filter((eid) => eid.includes('battery_serial_number')) : [];
 	}
 	private get _invertors(): string[] {
-		return this.hass
-			? Object.keys(this.hass.states).filter((eid) =>
-					/^sensor\.givtcp_[a-zA-Z]{2}\d{4}[a-zA-Z]\d{3}_invertor_serial_number$/g.test(eid)
-			  )
-			: [];
+		return this.hass ? Object.keys(this.hass.states).filter((eid) => eid.includes('invertor_serial_number')) : [];
 	}
 	private get _defaults(): LovelaceCardConfig {
 		return ConfigUtils.getDefaults(this._config);

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,10 @@ export interface FlowData {
 	in?: FlowTotal;
 	out?: FlowTotal;
 }
+export interface entityName {
+	prefix: string;
+	suffix: string;
+}
 export enum LineStyle {
 	Straight = 'straight',
 	Curved = 'curved',


### PR DESCRIPTION
Entity names no longer always have serial number in the latest GivTCP, this now supports custom named entities and suffixed entities.