### PR TITLE
fix(editor): keep saved multi-select entities valid

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -100,12 +100,8 @@ export const INVERTER_BATTERY_SCHEMA = (config: LovelaceCardConfig, invertors: s
 	const singleInvertor = config.single_invertor !== undefined ? config.single_invertor : SINGLE_INVERTOR_DEFAULT;
 	const singleBattery = config.single_battery !== undefined ? config.single_battery : SINGLE_BATTERY_DEFAULT;
 
-	const invertorList = singleInvertor
-		? invertors
-		: invertors.filter((x) => (config.invertors?.length > 0 ? config.invertors?.indexOf(x) === -1 : true));
-	const batteryList = singleBattery
-		? batteries
-		: batteries.filter((x) => (config.batteries?.length > 0 ? config.batteries?.indexOf(x) === -1 : true));
+	const invertorList = invertors;
+	const batteryList = batteries;
 	return [
 		{
 			type: 'grid',


### PR DESCRIPTION
## Summary
- keep inverter and battery selector options stable when editing saved multi-select configurations
- stop filtering already-selected entities out of the selector source list so Home Assistant can still resolve saved selections
- fix the editor error shown after saving and re-opening cards with multiple inverters or batteries